### PR TITLE
Add basic audiobook library and player

### DIFF
--- a/Buk/ContentView.swift
+++ b/Buk/ContentView.swift
@@ -1,21 +1,8 @@
-//
-//  ContentView.swift
-//  Buk
-//
-//  Created by Luke Charman on 03/08/2025.
-//
-
 import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        LibraryView()
     }
 }
 

--- a/Buk/Models/Audiobook.swift
+++ b/Buk/Models/Audiobook.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+
+struct Audiobook: Identifiable, Codable {
+    struct Chapter: Identifiable, Codable {
+        let id: UUID
+        let title: String
+        let startTime: TimeInterval
+    }
+
+    let id: UUID
+    let title: String
+    let fileName: String
+    let artworkData: Data?
+    let chapters: [Chapter]
+
+    var artworkImage: Image? {
+        guard let artworkData, let uiImage = UIImage(data: artworkData) else { return nil }
+        return Image(uiImage: uiImage)
+    }
+}

--- a/Buk/ViewModels/LibraryViewModel.swift
+++ b/Buk/ViewModels/LibraryViewModel.swift
@@ -1,0 +1,80 @@
+import Foundation
+import AVFoundation
+import SwiftUI
+
+@MainActor
+final class LibraryViewModel: ObservableObject {
+    @Published private(set) var books: [Audiobook] = []
+
+    private static let storageKey = "audiobooks"
+
+    static let libraryFolder: URL = {
+        let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Audiobooks", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }()
+
+    init() {
+        load()
+    }
+
+    private func load() {
+        guard
+            let data = UserDefaults.standard.data(forKey: Self.storageKey),
+            let decoded = try? JSONDecoder().decode([Audiobook].self, from: data)
+        else { return }
+        books = decoded
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(books) else { return }
+        UserDefaults.standard.set(data, forKey: Self.storageKey)
+    }
+
+    func importBook(from url: URL) async throws {
+        let destination = Self.libraryFolder.appendingPathComponent(url.lastPathComponent)
+        if !FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.copyItem(at: url, to: destination)
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try? destination.setResourceValues(values)
+        }
+
+        let asset = AVURLAsset(url: destination)
+        let metadata = try await asset.load(.commonMetadata)
+        let title: String
+        if let item = metadata.first(where: { $0.commonKey?.rawValue == "title" }),
+           let value = try? await item.load(.stringValue) {
+            title = value
+        } else {
+            title = destination.deletingPathExtension().lastPathComponent
+        }
+
+        let artworkData: Data?
+        if let item = metadata.first(where: { $0.commonKey?.rawValue == "artwork" }),
+           let data = try? await item.load(.dataValue) {
+            artworkData = data
+        } else {
+            artworkData = nil
+        }
+
+        let chapters = try await Self.loadChapters(for: asset)
+        let book = Audiobook(id: UUID(), title: title, fileName: destination.lastPathComponent, artworkData: artworkData, chapters: chapters)
+        books.append(book)
+        save()
+    }
+
+    private static func loadChapters(for asset: AVURLAsset) async throws -> [Audiobook.Chapter] {
+        var result: [Audiobook.Chapter] = []
+        let locales = try await asset.load(.availableChapterLocales)
+        guard let locale = locales.first else { return result }
+        let groups = try await asset.chapterMetadataGroups(withTitleLocale: locale)
+        for (index, group) in groups.enumerated() {
+            let items = try await group.load(.items)
+            let title = (try? await items.first(where: { $0.commonKey?.rawValue == "title" })?.load(.stringValue)) ?? "Chapter \(index + 1)"
+            let timeRange = try await group.load(.timeRange)
+            result.append(.init(id: UUID(), title: title, startTime: timeRange.start.seconds))
+        }
+        return result
+    }
+}

--- a/Buk/ViewModels/PlayerViewModel.swift
+++ b/Buk/ViewModels/PlayerViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+import AVFoundation
+
+@MainActor
+final class PlayerViewModel: ObservableObject {
+    @Published private(set) var isPlaying = false
+    @Published private(set) var currentChapterIndex: Int
+
+    let book: Audiobook
+    private let player: AVPlayer
+
+    init(book: Audiobook, startAt index: Int) {
+        self.book = book
+        self.currentChapterIndex = index
+        let url = LibraryViewModel.libraryFolder.appendingPathComponent(book.fileName)
+        self.player = AVPlayer(url: url)
+        seek(to: book.chapters[index].startTime)
+    }
+
+    func togglePlay() {
+        if isPlaying { pause() } else { play() }
+    }
+
+    func play() {
+        player.play()
+        isPlaying = true
+    }
+
+    func pause() {
+        player.pause()
+        isPlaying = false
+    }
+
+    func nextChapter() {
+        guard currentChapterIndex + 1 < book.chapters.count else { return }
+        currentChapterIndex += 1
+        seek(to: book.chapters[currentChapterIndex].startTime)
+    }
+
+    func previousChapter() {
+        guard currentChapterIndex > 0 else { return }
+        currentChapterIndex -= 1
+        seek(to: book.chapters[currentChapterIndex].startTime)
+    }
+
+    private func seek(to time: TimeInterval) {
+        let cmTime = CMTime(seconds: time, preferredTimescale: 1)
+        player.seek(to: cmTime)
+    }
+}

--- a/Buk/Views/ChapterListView.swift
+++ b/Buk/Views/ChapterListView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ChapterListView: View {
+    let book: Audiobook
+
+    var body: some View {
+        List {
+            ForEach(Array(book.chapters.enumerated()), id: \.1.id) { index, chapter in
+                NavigationLink(chapter.title) {
+                    PlayerView(book: book, startIndex: index)
+                }
+            }
+        }
+        .navigationTitle(book.title)
+    }
+}

--- a/Buk/Views/LibraryView.swift
+++ b/Buk/Views/LibraryView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct LibraryView: View {
+    @StateObject private var viewModel = LibraryViewModel()
+    @State private var showImporter = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(viewModel.books) { book in
+                    NavigationLink(book.title) {
+                        ChapterListView(book: book)
+                    }
+                }
+            }
+            .navigationTitle("Library")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showImporter = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .fileImporter(isPresented: $showImporter,
+                          allowedContentTypes: [UTType(filenameExtension: "m4b")!],
+                          allowsMultipleSelection: false) { result in
+                switch result {
+                case .success(let url):
+                    Task { try? await viewModel.importBook(from: url) }
+                case .failure:
+                    break
+                }
+            }
+        }
+    }
+}

--- a/Buk/Views/PlayerView.swift
+++ b/Buk/Views/PlayerView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct PlayerView: View {
+    @StateObject private var viewModel: PlayerViewModel
+
+    init(book: Audiobook, startIndex: Int) {
+        _viewModel = StateObject(wrappedValue: PlayerViewModel(book: book, startAt: startIndex))
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if let image = viewModel.book.artworkImage {
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 200)
+            }
+            Text(viewModel.book.title).font(.title)
+            Text(viewModel.book.chapters[viewModel.currentChapterIndex].title)
+            HStack(spacing: 40) {
+                Button(action: viewModel.previousChapter) {
+                    Image(systemName: "backward.end.fill")
+                }.disabled(viewModel.currentChapterIndex == 0)
+
+                Button(action: viewModel.togglePlay) {
+                    Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.largeTitle)
+                }
+
+                Button(action: viewModel.nextChapter) {
+                    Image(systemName: "forward.end.fill")
+                }.disabled(viewModel.currentChapterIndex == viewModel.book.chapters.count - 1)
+            }
+        }
+        .padding()
+    }
+}

--- a/BukTests/BukTests.swift
+++ b/BukTests/BukTests.swift
@@ -1,16 +1,29 @@
-//
-//  BukTests.swift
-//  BukTests
-//
-//  Created by Luke Charman on 03/08/2025.
-//
+import XCTest
+@testable import Buk
 
-import Testing
-
-struct BukTests {
-
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+final class BukTests: XCTestCase {
+    func testArtworkImageConversion() {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1))
+        let image = renderer.image { ctx in
+            UIColor.red.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        let data = image.pngData()
+        let book = Audiobook(id: UUID(), title: "Test", fileName: "t.m4b", artworkData: data, chapters: [])
+        XCTAssertNotNil(book.artworkImage)
     }
 
+    func testPlayerChapterNavigation() {
+        let chapters = [
+            Audiobook.Chapter(id: UUID(), title: "One", startTime: 0),
+            Audiobook.Chapter(id: UUID(), title: "Two", startTime: 10)
+        ]
+        let book = Audiobook(id: UUID(), title: "Test", fileName: "t.m4b", artworkData: nil, chapters: chapters)
+        let vm = PlayerViewModel(book: book, startAt: 0)
+        XCTAssertEqual(vm.currentChapterIndex, 0)
+        vm.nextChapter()
+        XCTAssertEqual(vm.currentChapterIndex, 1)
+        vm.previousChapter()
+        XCTAssertEqual(vm.currentChapterIndex, 0)
+    }
 }


### PR DESCRIPTION
## Summary
- Implement `Audiobook` model and `LibraryViewModel` for importing `.m4b` files, persisting metadata and chapters, and excluding imports from iCloud backups
- Build SwiftUI views for library, chapter listing, and a simple player with chapter navigation and artwork display
- Add unit tests for image conversion and chapter navigation logic

## Testing
- `xcodebuild test -project Buk.xcodeproj -scheme Buk -destination 'platform=iOS Simulator,name=iPhone 15'` *(failed: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_688fb816bdd0832cbeeb0f94428924fa