### PR TITLE
Add playback scrubbing and speed controls

### DIFF
--- a/Buk/ViewModels/PlayerViewModel.swift
+++ b/Buk/ViewModels/PlayerViewModel.swift
@@ -6,16 +6,32 @@ import AVFoundation
 final class PlayerViewModel: ObservableObject {
     @Published private(set) var isPlaying = false
     @Published private(set) var currentChapterIndex: Int
+    @Published var playbackRate: Float = 1.0 {
+        didSet {
+            if isPlaying {
+                player.rate = playbackRate
+            }
+        }
+    }
+    @Published private(set) var elapsedTime: TimeInterval = 0
 
     let book: Audiobook
     private let player: AVPlayer
+    private var timeObserver: Any?
 
     init(book: Audiobook, startAt index: Int) {
         self.book = book
         self.currentChapterIndex = index
         let url = LibraryViewModel.libraryFolder.appendingPathComponent(book.fileName)
         self.player = AVPlayer(url: url)
+        addTimeObserver()
         seek(to: book.chapters[index].startTime)
+    }
+
+    deinit {
+        if let timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
     }
 
     func togglePlay() {
@@ -24,6 +40,7 @@ final class PlayerViewModel: ObservableObject {
 
     func play() {
         player.play()
+        player.rate = playbackRate
         isPlaying = true
     }
 
@@ -33,19 +50,78 @@ final class PlayerViewModel: ObservableObject {
     }
 
     func nextChapter() {
-        guard currentChapterIndex + 1 < book.chapters.count else { return }
-        currentChapterIndex += 1
-        seek(to: book.chapters[currentChapterIndex].startTime)
+        let nextIndex = currentChapterIndex + 1
+        guard nextIndex < book.chapters.count else { return }
+        seek(to: book.chapters[nextIndex].startTime)
     }
 
     func previousChapter() {
-        guard currentChapterIndex > 0 else { return }
-        currentChapterIndex -= 1
-        seek(to: book.chapters[currentChapterIndex].startTime)
+        let prevIndex = currentChapterIndex - 1
+        guard prevIndex >= 0 else { return }
+        seek(to: book.chapters[prevIndex].startTime)
+    }
+
+    func skipForward15() {
+        let newTime = min(elapsedTime + 15, totalDuration)
+        seek(to: newTime)
+    }
+
+    func skipBackward15() {
+        let newTime = max(elapsedTime - 15, 0)
+        seek(to: newTime)
+    }
+
+    var totalDuration: TimeInterval {
+        player.currentItem?.asset.duration.seconds ?? 0
+    }
+
+    var currentChapterStart: TimeInterval {
+        book.chapters[currentChapterIndex].startTime
+    }
+
+    var currentChapterEnd: TimeInterval {
+        if currentChapterIndex + 1 < book.chapters.count {
+            return book.chapters[currentChapterIndex + 1].startTime
+        } else {
+            return totalDuration
+        }
+    }
+
+    var currentChapterDuration: TimeInterval {
+        currentChapterEnd - currentChapterStart
+    }
+
+    var chapterProgress: Double {
+        let duration = currentChapterDuration
+        guard duration > 0 else { return 0 }
+        return (elapsedTime - currentChapterStart) / duration
+    }
+
+    func seekToChapterProgress(_ progress: Double) {
+        let clamped = max(0, min(1, progress))
+        let time = currentChapterStart + clamped * currentChapterDuration
+        seek(to: time)
+    }
+
+    private func addTimeObserver() {
+        let interval = CMTime(seconds: 0.5, preferredTimescale: 600)
+        timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            guard let self else { return }
+            elapsedTime = time.seconds
+            updateCurrentChapter(for: time.seconds)
+        }
+    }
+
+    private func updateCurrentChapter(for time: TimeInterval) {
+        if let index = book.chapters.lastIndex(where: { time >= $0.startTime }) {
+            currentChapterIndex = index
+        }
     }
 
     private func seek(to time: TimeInterval) {
         let cmTime = CMTime(seconds: time, preferredTimescale: 1)
         player.seek(to: cmTime)
+        elapsedTime = time
+        updateCurrentChapter(for: time)
     }
 }

--- a/Buk/Views/PlayerView.swift
+++ b/Buk/Views/PlayerView.swift
@@ -17,19 +17,35 @@ struct PlayerView: View {
             }
             Text(viewModel.book.title).font(.title)
             Text(viewModel.book.chapters[viewModel.currentChapterIndex].title)
+            Slider(value: Binding(get: { viewModel.chapterProgress },
+                                  set: { viewModel.seekToChapterProgress($0) }), in: 0...1)
             HStack(spacing: 40) {
                 Button(action: viewModel.previousChapter) {
                     Image(systemName: "backward.end.fill")
                 }.disabled(viewModel.currentChapterIndex == 0)
+
+                Button(action: viewModel.skipBackward15) {
+                    Image(systemName: "gobackward.15")
+                }
 
                 Button(action: viewModel.togglePlay) {
                     Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
                         .font(.largeTitle)
                 }
 
+                Button(action: viewModel.skipForward15) {
+                    Image(systemName: "goforward.15")
+                }
+
                 Button(action: viewModel.nextChapter) {
                     Image(systemName: "forward.end.fill")
                 }.disabled(viewModel.currentChapterIndex == viewModel.book.chapters.count - 1)
+            }
+            HStack {
+                Text("Speed")
+                Slider(value: $viewModel.playbackRate, in: 0.75...2.0, step: 0.25)
+                Text(String(format: "%.2fx", viewModel.playbackRate))
+                    .monospacedDigit()
             }
         }
         .padding()

--- a/BukTests/BukTests.swift
+++ b/BukTests/BukTests.swift
@@ -26,4 +26,18 @@ final class BukTests: XCTestCase {
         vm.previousChapter()
         XCTAssertEqual(vm.currentChapterIndex, 0)
     }
+
+    func testSkipForwardBackward() {
+        let chapters = [
+            Audiobook.Chapter(id: UUID(), title: "One", startTime: 0),
+            Audiobook.Chapter(id: UUID(), title: "Two", startTime: 30)
+        ]
+        let book = Audiobook(id: UUID(), title: "Test", fileName: "t.m4b", artworkData: nil, chapters: chapters)
+        let vm = PlayerViewModel(book: book, startAt: 0)
+        XCTAssertEqual(vm.elapsedTime, 0, accuracy: 0.01)
+        vm.skipForward15()
+        XCTAssertEqual(vm.elapsedTime, 15, accuracy: 0.01)
+        vm.skipBackward15()
+        XCTAssertEqual(vm.elapsedTime, 0, accuracy: 0.01)
+    }
 }


### PR DESCRIPTION
## Summary
- allow chapter scrubbing with a progress slider
- add 15 second skip forward/back controls
- expose adjustable playback speed from 0.75x to 2x
- test skip forward/back logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689315491ac8832c8e5cb8a37a5eff8f